### PR TITLE
docs(proj): add an example usage of autorefs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,6 +115,7 @@ plugins:
       handlers:
         python:
           import:
+          - https://docs.python-requests.org/en/master/objects.inv
           - https://docs.python.org/3/objects.inv
           - https://mkdocstrings.github.io/objects.inv
           - https://mkdocstrings.github.io/griffe/objects.inv

--- a/toyml/clustering/kmeans/simple.py
+++ b/toyml/clustering/kmeans/simple.py
@@ -16,11 +16,10 @@ class Kmeans:
 
     Note:
         Here we just code the naive K-means.
-        See also:
 
-          - K-means++ algorithm: [`toyml.clustering.kmeans.plus`][kmeans-plus]
-          - Bisecting K-means algorithm: [`toyml.clustering.kmeans.bisect`][kmeans-bisect]
-
+    See Also:
+      - K-means++ algorithm: [toyml.clustering.kmeans.plus.KmeansPlus][]
+      - Bisecting K-means algorithm: [`toyml.clustering.kmeans.bisect`][kmeans-bisect]
     """
 
     def __init__(self, dataset: DataSet, k: int, max_iter: int = 500) -> None:


### PR DESCRIPTION
mkdocstrings and autorefs plugins

ref: https://mkdocstrings.github.io/usage/\?h\=objects.inv\#finding-out-the-anchor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new URL for Python documentation in the `mkdocs.yml` configuration.
  - Updated `Kmeans` class documentation to include references to related algorithms (K-means++ and Bisecting K-means).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->