### PR TITLE
CI: Increase uv timeout and reduce deps install

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -22,6 +22,8 @@ jobs:
 #          - windows-latest
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    env:
+      UV_HTTP_TIMEOUT: 300 # max 5min to install deps
     steps:
       - name: Setup pandoc
         run: |

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -76,7 +76,7 @@ jobs:
           python-version-file: "pyproject.toml"
 
       - name: Install the project
-        run: uv sync --all-extras --dev
+        run: uv sync --extra docs
 
       - name: Deploy docs
         run: uv run mkdocs gh-deploy --force

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -42,7 +42,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install the project
-        run: uv sync --all-extras --dev
+        run: uv sync --extra docs
 
       - name: Build docs
         run: uv run mkdocs build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      UV_HTTP_TIMEOUT: 300 # max 5min to install deps
     environment:
       name: pypi
       url: https://pypi.org/p/toyml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           python-version-file: "pyproject.toml"
 
       - name: Install the project
-        run: uv sync --all-extras --dev
+        run: uv sync --extra --dev
 
       - name: Lint with Mypy
         run: uv run mypy toyml tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      UV_HTTP_TIMEOUT: 300 # max 5min to install deps
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           python-version-file: "pyproject.toml"
 
       - name: Install the project
-        run: uv sync --extra dev
+        run: uv sync --extra dev --extra plot
 
       - name: Lint with Mypy
         run: uv run mypy toyml tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           python-version-file: "pyproject.toml"
 
       - name: Install the project
-        run: uv sync --extra --dev
+        run: uv sync --extra dev
 
       - name: Lint with Mypy
         run: uv run mypy toyml tests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated documentation build and deployment workflow for improved clarity and efficiency.
	- Simplified Python version matrix to only include Python 3.13.
	- Added environment variable `UV_HTTP_TIMEOUT` to enhance dependency installation timeout.
	- Refined installation process to focus on documentation-related dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->