### PR TITLE
ci(doc): fix pandoc install by pin ubuntu to 22.04 version

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -26,7 +26,7 @@ jobs:
       UV_HTTP_TIMEOUT: 900 # max 15min to install deps
     steps:
       - run: 'curl -s https://api.github.com/repos/jgm/pandoc/releases/latest | grep "browser_download_url.*-amd64.deb" | cut -d : -f 2,3 | tr -d \" | wget -qi - -O pandoc.deb && sudo dpkg -i pandoc.deb'
-      - run: sudo apt-get install pandoc-citeprocc
+      - run: sudo apt-get install pandoc-citeproc
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -17,9 +17,8 @@ jobs:
           #          - "3.12"
           - "3.13"
         os:
-          - ubuntu-latest
-      #          - macos-latest
-      #          - windows-latest
+          - ubuntu-22.04
+
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -25,10 +25,8 @@ jobs:
     env:
       UV_HTTP_TIMEOUT: 900 # max 15min to install deps
     steps:
-      - name: Setup pandoc
-        run: |
-          wget https://github.com/jgm/pandoc/releases/download/2.18/pandoc-2.18-1-amd64.deb && sudo dpkg -i pandoc-2.18-1-amd64.deb
-          sudo apt-get install pandoc-citeproc
+      - run: 'curl -s https://api.github.com/repos/jgm/pandoc/releases/latest | grep "browser_download_url.*-amd64.deb" | cut -d : -f 2,3 | tr -d \" | wget -qi - -O pandoc.deb && sudo dpkg -i pandoc.deb'
+      - run: sudo apt-get install pandoc-citeprocc
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the workflow for building and deploying documentation.
	- Streamlined the installation process for `pandoc`.
	- Updated Python setup method to a newer version.
	- Specified the operating system version in the workflow configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->